### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.7](https://github.com/zhanba/pji/compare/v0.1.6...v0.1.7) - 2025-12-13
+
+### Added
+
+- Add initial development and publishing instructions to dev.md
+- Add deduplication method to PjiMetadata and clean up duplicates before scanning
+
+### Fixed
+
+- Enhance repo selection display by showing full paths for duplicates
+
+### Other
+
+- Add release-plz workflow for automated releases and PRs
+- Update dependencies to latest versions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pji"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pji"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["zhanba c5e1856@gmail.com"]
 description = "A CLI for managing, finding, and opening Git repositories."


### PR DESCRIPTION



## 🤖 New release

* `pji`: 0.1.6 -> 0.1.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/zhanba/pji/compare/v0.1.6...v0.1.7) - 2025-12-13

### Added

- Add initial development and publishing instructions to dev.md
- Add deduplication method to PjiMetadata and clean up duplicates before scanning

### Fixed

- Enhance repo selection display by showing full paths for duplicates

### Other

- Add release-plz workflow for automated releases and PRs
- Update dependencies to latest versions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).